### PR TITLE
Buffer is required

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+window.Buffer = Buffer;
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";


### PR DESCRIPTION

 the default bundler that comes with create react app(webpack 5) does not have polyfill Buffer. Fix it by adding-
```
import * as buffer from "buffer";
window.Buffer = buffer.Buffer;
```